### PR TITLE
Export same API as `dotenv`

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,11 +10,11 @@
     "toml-j0.4": "^1.1.1"
   },
   "devDependencies": {
-    "@types/jest": "^21.1.8",
-    "@types/node": "^8.0.58",
-    "jest": "^21.2.1",
-    "ts-jest": "^21.2.4",
-    "typescript": "^2.6.2"
+    "@types/jest": "^22.2.3",
+    "@types/node": "^9.6.6",
+    "jest": "^22.4.3",
+    "ts-jest": "^22.4.4",
+    "typescript": "^2.8.1"
   },
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,14 +6,19 @@ export interface Options {
   encoding?: string
   intoEnv?: boolean
   path?: string
+  useJson?: boolean
 }
 
-const loadIntoEnv = (env: Record<string, any>, prefix = "") => {
+const loadIntoEnv = function(env: Record<string, any>, useJson=false, prefix="")
+{
   for (const key in env) {
     const value: any = env[key]
 
     if (typeof value === "string")
       process.env[prefix + key] = value;
+
+    else if (useJson)
+      process.env[prefix + key] = JSON.stringify(value);
 
     else if (typeof value === "number")
       process.env[prefix + key] = value.toString();
@@ -22,19 +27,20 @@ const loadIntoEnv = (env: Record<string, any>, prefix = "") => {
       process.env[prefix + key] = value.toJSON();
 
     else if (typeof value === "object")
-      loadIntoEnv(value, `${prefix}${key}_`)
+      loadIntoEnv(value, useJson, `${prefix}${key}_`)
   }
 }
 
 export const load = function({
   encoding = 'utf8',
   intoEnv = true,
-  path = '.env.toml'
+  path = '.env.toml',
+  useJson = false
 }: Options)
 {
   try {
     const parsed = toml.parse(readFileSync(path, encoding));
-    intoEnv !== false && loadIntoEnv(parsed)
+    intoEnv !== false && loadIntoEnv(parsed, useJson)
     return {parsed}
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,11 +1,11 @@
 import { readFileSync } from "fs"
-import { resolve } from "path"
+
 import * as toml from "toml-j0.4"
 
 export interface Options {
-  path?: string
+  encoding?: string
   intoEnv?: boolean
-  throwErr?: boolean
+  path?: string
 }
 
 const loadIntoEnv = (env: Record<string, any>, prefix = "") => {
@@ -26,18 +26,20 @@ const loadIntoEnv = (env: Record<string, any>, prefix = "") => {
   }
 }
 
-export const load = ({ path = ".env.toml", intoEnv = true, throwErr = false }: Options) => {
-
+export const load = function({
+  encoding = 'utf8',
+  intoEnv = true,
+  path = '.env.toml'
+}: Options)
+{
   try {
-    const env = toml.parse(readFileSync(resolve(process.cwd(), path)).toString());
-    intoEnv !== false && loadIntoEnv(env)
-    return env
+    const parsed = toml.parse(readFileSync(path, encoding));
+    intoEnv !== false && loadIntoEnv(parsed)
+    return {parsed}
   }
 
-  catch (e) {
-    if (throwErr)
-     throw new Error(e);
-    return {}
+  catch (error) {
+    return {error}
   }
 }
 

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -9,7 +9,7 @@ describe("Load .env", () => {
   })
 
   it("Parses and returns toml without env", () => {
-    const env = load({ path: "./test/.env.toml", intoEnv: false });
+    const {parsed: env} = load({ path: "./test/.env.toml", intoEnv: false });
     expect(env.topKey).toEqual("topValue")
     expect(env.SECTION3.date).toBeDefined()
     expect(Array.isArray(env.SECTION4.arr)).toBeTruthy()

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -8,6 +8,13 @@ describe("Load .env", () => {
     expect(process.env.SECTION2_KEY).toEqual("123")
   })
 
+  it("Properly loads toml file into env as JSON", () => {
+    load({ path: "./test/.env.toml", intoEnv: true, useJson: true });
+    expect(process.env.topKey).toEqual("topValue")
+    expect(JSON.parse(process.env.SECTION1)).toEqual({KEY: 'value'})
+    expect(JSON.parse(process.env.SECTION2)).toEqual({KEY: 123})
+  })
+
   it("Parses and returns toml without env", () => {
     const {parsed: env} = load({ path: "./test/.env.toml", intoEnv: false });
     expect(env.topKey).toEqual("topValue")


### PR DESCRIPTION
This pull-request propose to export the same API as `dotenv` so both modules can be interchangeable. Also it adds an option to store sections as JSON objects instead of environment variables with their path separated by underscores, and also updates the project dependencies. Tests are fully workfing.